### PR TITLE
fix(deploy-kind): increase timeout for Helm deployment

### DIFF
--- a/scripts/deploy-on-kind.sh
+++ b/scripts/deploy-on-kind.sh
@@ -212,6 +212,7 @@ function deploy_korifi() {
       --set=experimental.securityGroups.enabled="true" \
       --set=experimental.managedServices.trustInsecureBrokers="true" \
       --set=api.list.defaultPageSize="5000" \
+      --timeout="15m" \
       --wait
   }
   popd >/dev/null


### PR DESCRIPTION
# Problem
On my machine, deploying the Helm release took more than the [default `5m`](https://helm.sh/docs/intro/using_helm/#helpful-options-for-installupgraderollback) to run the `post-install`-hook.

<img width="1237" height="209" alt="Screenshot 2025-08-21 at 15 31 04" src="https://github.com/user-attachments/assets/e32328d9-3c85-4766-8726-cab3f12b0297" />

# Solution
Increase timeout.